### PR TITLE
Configurator now respects 'amend' with defaults

### DIFF
--- a/autoalbum/util.py
+++ b/autoalbum/util.py
@@ -1,0 +1,30 @@
+'''Utility functions mostly'''
+import json
+
+def load_json(json_path):
+    '''Load JSON utility function
+
+    I think manipulating files is ugly so here's a short utility to do this for me
+
+    Args:
+        json_path (PathLike): path to JSON file to load
+
+    Returns:
+        dict: Loaded JSON data
+    '''
+    data = {}
+    with open(json_path, 'r') as file:
+        data = json.load(file)
+    return data
+
+def save_json(json_path, data):
+    '''Save JSON utility function
+
+    I think manipulating files is ugly so here's a short utility to do this for me
+
+    Args:
+        json_path (PathLike): path to JSON file to write to
+        data (dict): data to write to JSON
+    '''
+    with open(json_path, 'w') as file:
+        json.dump(data, file)


### PR DESCRIPTION
Now, if you select "amend" in the case of an existing configuration, the
existing options are defaulted for you. (So you could just hit <return>
a bunch of times and the configuration file would wind up being the
same).

Because of a bug (lack of feature?) in PyInquirer, this required some
(commented) goofiness in configurator.py. Ah well.

Also split out json utilities into util.py. I suspect (read: know) I'll
need them later